### PR TITLE
Update android setup instructions for react-native 0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,33 @@ project(':CouchBase').projectDir = new File(rootProject.projectDir, '../node_mod
 * In `android/app/build.gradle`
 
 ```gradle
-...
+android {
+    ...
+    
+    // workaround for "duplicate files during packaging of APK" issue
+    // see https://groups.google.com/d/msg/adt-dev/bl5Rc4Szpzg/wC8cylTWuIEJ
+    packagingOptions {
+        exclude 'META-INF/ASL2.0'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+    }
+}
+
+
 dependencies {
     ...
     compile project(':CouchBase')
 }
+```
+
+* give internet and network-state access, in `android/app/src/main/AndroidManifest.xml`:
+ 
+```xml
+<manifest ...>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    ...
+</manifest>
 ```
 
 * register module (in MainActivity.java)
@@ -132,23 +154,18 @@ import com.upinion.CouchBase.CouchBasePackage;  // <--- import
 
 public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
   ......
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    mReactRootView = new ReactRootView(this);
-
-    mReactInstanceManager = ReactInstanceManager.builder()
-      .setApplication(getApplication())
-      .setBundleAssetName("index.android.bundle")
-      .setJSMainModuleName("index.android")
-      .addPackage(new MainReactPackage())
-      .addPackage(new CouchBasePackage())              // <------ add here
-      .setUseDeveloperSupport(BuildConfig.DEBUG)
-      .setInitialLifecycleState(LifecycleState.RESUMED)
-      .build();
-  ......
-
+    
+    /**
+     * A list of packages used by the app. If the app uses additional views
+     * or modules besides the default ones, add more packages here.
+     */
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+        new MainReactPackage(),
+        new CouchBasePackage()
+      );
+    }
 }
 ```
 


### PR DESCRIPTION
Add permissions, override `getPackages` and exclude some files to prevent compilation errors.
